### PR TITLE
feat(chat): enforce qc admin presence in chat rooms

### DIFF
--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -7,6 +7,7 @@ import { User } from '../models/userModel.js';
 import { uploadOnCloudinary } from '../utils/cloudinary.js';
 import { extractLinkPreview } from '../utils/linkPreview.js';
 import { verifyUser } from '../middleware/authMiddleware.js';
+import { ROLES } from '../config/roles.js';
 
 const router = express.Router();
 router.use(verifyUser());
@@ -104,21 +105,34 @@ router.route('/rooms').post(async (req, res) => {
       });
     }
 
-    // Use the members array sent from frontend
+    // Use the members array sent from frontend and ensure creator is included
     // Filter out any null/undefined values
     const validMembers = members.filter(memberId => memberId != null);
-    
+
+    if (!validMembers.map(id => id.toString()).includes(req.user._id.toString())) {
+      validMembers.push(req.user._id);
+    }
+
     console.log("Valid members after filtering:", validMembers);
-    
+
     // Validate that the member IDs exist in the database
-    const existingUsers = await User.find({ 
-      _id: { $in: validMembers } 
+    const existingUsers = await User.find({
+      _id: { $in: validMembers }
     }).select('_id name role');
-    
+
     console.log("Existing users found:", existingUsers);
-    
+
+    // Ensure at least one QC admin is part of the room
+    const hasQcAdmin = existingUsers.some(user => user.role === ROLES.QCADMIN);
+    if (!hasQcAdmin) {
+      return res.status(400).json({
+        success: false,
+        message: 'At least one QC Admin is required in a chat room'
+      });
+    }
+
     const existingUserIds = existingUsers.map(user => user._id.toString());
-    
+
     const chatRoom = new ChatRoom({
       name: name.trim(),
       description: description?.trim() || '',


### PR DESCRIPTION
## Summary
- ensure chat rooms include the creating user and validate at least one QC Admin is a member
- add roles import to chat routes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 276 problems)

------
https://chatgpt.com/codex/tasks/task_e_68b9312da18083239cf61bf709d05c3b