### PR TITLE
feat(chat): enforce qc admin presence in chat rooms

### DIFF
--- a/server/src/models/ChatMessage.js
+++ b/server/src/models/ChatMessage.js
@@ -8,7 +8,7 @@ const chatMessageSchema = new mongoose.Schema({
   },
   senderId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true
   },
   senderName: {
@@ -61,7 +61,7 @@ const chatMessageSchema = new mongoose.Schema({
   reactions: [{
     userId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+        ref: 'UserInfo'
     },
     emoji: String,
     createdAt: {
@@ -72,7 +72,7 @@ const chatMessageSchema = new mongoose.Schema({
   readBy: [{
     userId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+      ref: 'UserInfo'
     },
     readAt: {
       type: Date,
@@ -100,7 +100,7 @@ export const ChatMessage = mongoose.model('ChatMessage', chatMessageSchema);
 const userStatusSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+      ref: 'UserInfo',
     required: true,
     unique: true
   },

--- a/server/src/models/ChatRoom.js
+++ b/server/src/models/ChatRoom.js
@@ -19,16 +19,16 @@ const chatRoomSchema = new mongoose.Schema({
   },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true
   },
   members: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User'
+    ref: 'UserInfo'
   }],
   admins: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User'
+    ref: 'UserInfo'
   }],
   isPrivate: {
     type: Boolean,
@@ -38,7 +38,7 @@ const chatRoomSchema = new mongoose.Schema({
     content: String,
     senderId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+      ref: 'UserInfo'
     },
     timestamp: Date
   },

--- a/server/src/models/UserStatus.js
+++ b/server/src/models/UserStatus.js
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 const userStatusSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true,
     unique: true
   },

--- a/server/src/models/projectRole.js
+++ b/server/src/models/projectRole.js
@@ -9,7 +9,7 @@ const projectRoleSchema = new mongoose.Schema({
   },
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true,
     index: true
   },

--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -7,6 +7,7 @@ import { User } from '../models/userModel.js';
 import { uploadOnCloudinary } from '../utils/cloudinary.js';
 import { extractLinkPreview } from '../utils/linkPreview.js';
 import { verifyUser } from '../middleware/authMiddleware.js';
+import { ROLES } from '../config/roles.js';
 
 const router = express.Router();
 router.use(verifyUser());
@@ -104,21 +105,34 @@ router.route('/rooms').post(async (req, res) => {
       });
     }
 
-    // Use the members array sent from frontend
+    // Use the members array sent from frontend and ensure creator is included
     // Filter out any null/undefined values
     const validMembers = members.filter(memberId => memberId != null);
-    
+
+    if (!validMembers.map(id => id.toString()).includes(req.user._id.toString())) {
+      validMembers.push(req.user._id);
+    }
+
     console.log("Valid members after filtering:", validMembers);
-    
+
     // Validate that the member IDs exist in the database
-    const existingUsers = await User.find({ 
-      _id: { $in: validMembers } 
+    const existingUsers = await User.find({
+      _id: { $in: validMembers }
     }).select('_id name role');
-    
+
     console.log("Existing users found:", existingUsers);
-    
+
+    // Ensure at least one QC admin is part of the room
+    const hasQcAdmin = existingUsers.some(user => user.role === ROLES.QCADMIN);
+    if (!hasQcAdmin) {
+      return res.status(400).json({
+        success: false,
+        message: 'At least one QC Admin is required in a chat room'
+      });
+    }
+
     const existingUserIds = existingUsers.map(user => user._id.toString());
-    
+
     const chatRoom = new ChatRoom({
       name: name.trim(),
       description: description?.trim() || '',


### PR DESCRIPTION
## Summary
- ensure chat rooms include the creating user and validate at least one QC Admin is a member
- add roles import to chat routes
- update chat-related schemas to reference the UserInfo model

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 276 problems)


------
https://chatgpt.com/codex/tasks/task_e_68b9312da18083239cf61bf709d05c3b