### PR TITLE
feat(project): manage project-specific roles

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -47,6 +47,7 @@ import userSubTask from "./routes/userSubTask.js";
 import videosPdfSubTask from "./routes/videos&PdfSubTask.js";
 import screenRecordingRoutes from "./routes/screenRecordingRoutes.js";
 import notificationRoute from "./routes/notificationRoute.js";
+import projectRoleRoute from "./routes/projectRoles.js";
 
 import PlanRoute from "./adminPanel/routes/planRoute.js";
 import SuperAdminAuth from "./adminPanel/routes/superAdminAuth.js";
@@ -60,6 +61,7 @@ app.use("/user", userTracker);
 app.use("/user", cloudinaryScreenCapture);
 app.use("/user", userSubTask);
 app.use("/user", videosPdfSubTask);
+app.use("/user/project-roles", projectRoleRoute);
 app.use("/company", screenRecordingRoutes);
 app.use("/notifications", notificationRoute);
 

--- a/server/src/controllers/projectRoleController.js
+++ b/server/src/controllers/projectRoleController.js
@@ -1,0 +1,62 @@
+import mongoose from 'mongoose';
+import { asyncHandler } from '../utils/asyncHandler.js';
+import { apiResponse } from '../utils/apiResponse.js';
+import { apiError } from '../utils/apiError.js';
+import ProjectRole from '../models/projectRole.js';
+import { adminTask } from '../models/adminTask.js';
+import { User } from '../models/userModel.js';
+import { ROLES } from '../config/roles.js';
+
+// helper to get companyId from user
+const getUserCompanyId = (user) => {
+  if (user.role === ROLES.COMPANY) return user._id;
+  if ((user.role === ROLES.USER || user.role === ROLES.QCADMIN) && user.companyId) return user.companyId;
+  return null;
+};
+
+// Ensure project belongs to company
+const validateProjectCompany = async (projectId, companyId) => {
+  const project = await adminTask.findOne({ _id: projectId, companyId });
+  if (!project) throw new apiError(403, 'Project not found or access denied');
+  return project;
+};
+
+// List members for a project
+const listProjectMembers = asyncHandler(async (req, res) => {
+  const { projectId } = req.params;
+  const companyId = getUserCompanyId(req.user);
+  if (!mongoose.isValidObjectId(projectId)) throw new apiError(400, 'Invalid projectId');
+  if (!companyId) throw new apiError(400, 'Company context required');
+  await validateProjectCompany(projectId, companyId);
+  const roles = await ProjectRole.find({ projectId, isActive: true }).populate('userId', 'name avatar role');
+  return res.status(200).json(new apiResponse(200, roles, 'Project members fetched'));
+});
+
+// Assign or update role for a member in a project
+const assignProjectRole = asyncHandler(async (req, res) => {
+  const { projectId } = req.params;
+  const { userId, role } = req.body;
+  const companyId = getUserCompanyId(req.user);
+  if (!projectId || !userId || !role) throw new apiError(400, 'projectId, userId and role are required');
+  if (!Object.values(ROLES).includes(role)) throw new apiError(400, 'Invalid role');
+  await validateProjectCompany(projectId, companyId);
+  const user = await User.findOne({ _id: userId, $or: [{ _id: companyId }, { companyId }] });
+  if (!user) throw new apiError(404, 'User not found in your company');
+  const pr = await ProjectRole.findOneAndUpdate(
+    { projectId, userId },
+    { role, isActive: true },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+  return res.status(200).json(new apiResponse(200, pr, 'Role assigned'));
+});
+
+// Remove member from project
+const removeProjectMember = asyncHandler(async (req, res) => {
+  const { projectId, userId } = req.params;
+  const companyId = getUserCompanyId(req.user);
+  await validateProjectCompany(projectId, companyId);
+  await ProjectRole.findOneAndUpdate({ projectId, userId }, { isActive: false });
+  return res.status(200).json(new apiResponse(200, null, 'Member removed'));
+});
+
+export { listProjectMembers, assignProjectRole, removeProjectMember };

--- a/server/src/models/ChatMessage.js
+++ b/server/src/models/ChatMessage.js
@@ -8,7 +8,7 @@ const chatMessageSchema = new mongoose.Schema({
   },
   senderId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true
   },
   senderName: {
@@ -61,7 +61,7 @@ const chatMessageSchema = new mongoose.Schema({
   reactions: [{
     userId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+        ref: 'UserInfo'
     },
     emoji: String,
     createdAt: {
@@ -72,7 +72,7 @@ const chatMessageSchema = new mongoose.Schema({
   readBy: [{
     userId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+      ref: 'UserInfo'
     },
     readAt: {
       type: Date,
@@ -100,7 +100,7 @@ export const ChatMessage = mongoose.model('ChatMessage', chatMessageSchema);
 const userStatusSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+      ref: 'UserInfo',
     required: true,
     unique: true
   },

--- a/server/src/models/ChatRoom.js
+++ b/server/src/models/ChatRoom.js
@@ -19,16 +19,16 @@ const chatRoomSchema = new mongoose.Schema({
   },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true
   },
   members: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User'
+    ref: 'UserInfo'
   }],
   admins: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User'
+    ref: 'UserInfo'
   }],
   isPrivate: {
     type: Boolean,
@@ -38,7 +38,7 @@ const chatRoomSchema = new mongoose.Schema({
     content: String,
     senderId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+      ref: 'UserInfo'
     },
     timestamp: Date
   },

--- a/server/src/models/UserStatus.js
+++ b/server/src/models/UserStatus.js
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 const userStatusSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true,
     unique: true
   },

--- a/server/src/models/projectRole.js
+++ b/server/src/models/projectRole.js
@@ -9,7 +9,7 @@ const projectRoleSchema = new mongoose.Schema({
   },
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true,
     index: true
   },

--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -4,9 +4,11 @@ import multer from 'multer';
 import ChatRoom from '../models/ChatRoom.js';
 import { ChatMessage, UserStatus } from '../models/ChatMessage.js';
 import { User } from '../models/userModel.js';
+import ProjectRole from '../models/projectRole.js';
 import { uploadOnCloudinary } from '../utils/cloudinary.js';
 import { extractLinkPreview } from '../utils/linkPreview.js';
 import { verifyUser } from '../middleware/authMiddleware.js';
+import { ROLES } from '../config/roles.js';
 
 const router = express.Router();
 router.use(verifyUser());
@@ -34,6 +36,33 @@ const upload = multer({
 console.log('Chat routes loaded');
 
 // ---------------------- Chat Room Routes ----------------------
+
+// Get all users assigned to a project for selection in chat rooms
+router.route('/rooms/:projectId/users').get(async (req, res) => {
+  try {
+    const { projectId } = req.params;
+
+    const projectUsers = await ProjectRole.find({ projectId, isActive: true })
+      .populate('userId', 'name avatar email');
+
+    const users = projectUsers.map(pr => ({
+      _id: pr.userId._id,
+      name: pr.userId.name,
+      avatar: pr.userId.avatar,
+      email: pr.userId.email,
+      role: pr.role
+    }));
+
+    res.status(200).json({ success: true, data: users });
+  } catch (error) {
+    console.error('Get project users error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to fetch project users',
+      error: error.message
+    });
+  }
+});
 
 // Get all chat rooms for a project
 router.route('/rooms/:projectId').get(async (req, res) => {
@@ -104,28 +133,54 @@ router.route('/rooms').post(async (req, res) => {
       });
     }
 
-    // Use the members array sent from frontend
+    // Use the members array sent from frontend and ensure creator is included
     // Filter out any null/undefined values
     const validMembers = members.filter(memberId => memberId != null);
-    
+
+    if (!validMembers.map(id => id.toString()).includes(req.user._id.toString())) {
+      validMembers.push(req.user._id);
+    }
+
     console.log("Valid members after filtering:", validMembers);
-    
-    // Validate that the member IDs exist in the database
-    const existingUsers = await User.find({ 
-      _id: { $in: validMembers } 
-    }).select('_id name role');
-    
-    console.log("Existing users found:", existingUsers);
-    
-    const existingUserIds = existingUsers.map(user => user._id.toString());
-    
+
+    // Fetch project roles for provided members to ensure they belong to the project
+    const projectRoles = await ProjectRole.find({
+      projectId,
+      userId: { $in: validMembers },
+      isActive: true
+    }).populate('userId', 'name avatar role');
+
+    // Ensure the creator is part of the project
+    const memberIds = projectRoles.map(pr => pr.userId._id.toString());
+    if (!memberIds.includes(req.user._id.toString())) {
+      return res.status(403).json({
+        success: false,
+        message: 'Creator must be part of the project'
+      });
+    }
+
+    // Ensure at least one QC admin is part of the room
+    const hasQcAdmin = projectRoles.some(pr => pr.role === ROLES.QCADMIN);
+    if (!hasQcAdmin) {
+      return res.status(400).json({
+        success: false,
+        message: 'At least one QC Admin is required in a chat room'
+      });
+    }
+
+    const existingUserIds = [...new Set(memberIds)];
+
+    const adminIds = projectRoles
+      .filter(pr => pr.role === ROLES.QCADMIN)
+      .map(pr => pr.userId._id.toString());
+
     const chatRoom = new ChatRoom({
       name: name.trim(),
       description: description?.trim() || '',
       projectId,
       createdBy: req.user._id,
-      members: existingUserIds, // Use the members from frontend payload
-      admins: [req.user._id], // You can modify this logic as needed
+      members: existingUserIds, // Use the members from frontend payload filtered by project membership
+      admins: [...new Set([req.user._id.toString(), ...adminIds])],
       isPrivate
     });
 

--- a/server/src/routes/projectRoles.js
+++ b/server/src/routes/projectRoles.js
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { verifyUser } from '../middleware/authMiddleware.js';
+import { ROLES } from '../config/roles.js';
+import { listProjectMembers, assignProjectRole, removeProjectMember } from '../controllers/projectRoleController.js';
+
+const router = Router();
+
+// list members - accessible to company users and project members
+router.get('/:projectId', verifyUser([ROLES.COMPANY, ROLES.QCADMIN, ROLES.USER]), listProjectMembers);
+
+// assign/update role - company only
+router.post('/:projectId', verifyUser([ROLES.COMPANY]), assignProjectRole);
+
+// remove member - company only
+router.delete('/:projectId/:userId', verifyUser([ROLES.COMPANY]), removeProjectMember);
+
+export default router;

--- a/src/Pages/Dashboard/AddProjects/Chat/index.jsx
+++ b/src/Pages/Dashboard/AddProjects/Chat/index.jsx
@@ -25,10 +25,10 @@ import { useSocket } from '../../../../hooks/useSocket';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createChatRoom, getChatRooms, sendMessage as apiSendMessage,
-  getMessages, uploadChatFile, joinChatRoom as apiJoinChatRoom
+  getMessages, uploadChatFile, joinChatRoom as apiJoinChatRoom,
+  getProjectUsers
 } from '../../../../api/chat';
 import { toast } from 'react-toastify';
-import { getUserForSubTask } from '../../../../api/userSubTask';
 import PropTypes from 'prop-types';
 
 const ITEM_HEIGHT = 48;
@@ -40,6 +40,9 @@ const MenuProps = {
       width: 250,
     },
   },
+  // Keep menus within the dialog to prevent it from closing
+  // when selecting items
+  disablePortal: true,
 };
 
 const ProjectChat = ({ projectId }) => {
@@ -53,6 +56,7 @@ const ProjectChat = ({ projectId }) => {
   const [createRoomDialog, setCreateRoomDialog] = useState(false);
   const [newRoomData, setNewRoomData] = useState({ name: '', description: '', isPrivate: false });
   const [selectedQcAdmins, setSelectedQcAdmins] = useState([]);
+  const [selectedMembers, setSelectedMembers] = useState([]);
   const [isTyping, setIsTyping] = useState(false);
   const [typingUsers, setTypingUsers] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -88,7 +92,7 @@ const ProjectChat = ({ projectId }) => {
   // Fetch project users for room creation
   const { data: projectUsers } = useQuery({
     queryKey: ['projectUsers', projectId],
-    queryFn: () => getUserForSubTask(projectId),
+    queryFn: () => getProjectUsers(projectId),
     enabled: !!projectId
   });
 
@@ -100,6 +104,7 @@ const ProjectChat = ({ projectId }) => {
       setCreateRoomDialog(false);
       setNewRoomData({ name: '', description: '', isPrivate: false });
       setSelectedQcAdmins([]);
+      setSelectedMembers([]);
       setSelectedRoom(data.data);
       toast.success('Chat room created successfully!');
     },
@@ -138,8 +143,10 @@ const ProjectChat = ({ projectId }) => {
       setSelectedFile(null);
     }
   });
-  // Get QC Admins from project users
-  const qcAdmins = projectUsers?.data?.filter(user => user.role === 'qcadmin') || [];
+  // Separate project users by role
+  const allProjectUsers = projectUsers?.data?.filter(u => u._id !== user._id) || [];
+  const qcAdmins = allProjectUsers.filter(u => u.role === 'qcadmin');
+  const otherMembers = allProjectUsers.filter(u => u.role !== 'qcadmin');
 
   // Socket event listeners
   useEffect(() => {
@@ -196,13 +203,16 @@ const ProjectChat = ({ projectId }) => {
     }
   }, [selectedRoom, socket, isConnected, joinChatRoom, leaveChatRoom]);
 
-  // Initialize selected QC Admins when dialog opens
+  // Initialize selected members when dialog opens
   useEffect(() => {
     if (createRoomDialog) {
-      // Pre-select all QC Admins by default
-      setSelectedQcAdmins(qcAdmins.map(admin => admin._id));
+      const initialAdmins = user.role === 'qcadmin'
+        ? [user._id, ...qcAdmins.map(admin => admin._id)]
+        : qcAdmins.map(admin => admin._id);
+      setSelectedQcAdmins(initialAdmins);
+      setSelectedMembers([]);
     }
-  }, [createRoomDialog, qcAdmins]);
+  }, [createRoomDialog, qcAdmins, user]);
 
   // Handle send message
   const handleSendMessage = (messageData = null) => {
@@ -265,6 +275,12 @@ const ProjectChat = ({ projectId }) => {
     setSelectedQcAdmins(typeof value === 'string' ? value.split(',') : value);
   };
 
+  // Handle additional member selection change
+  const handleMemberChange = (event) => {
+    const value = event.target.value;
+    setSelectedMembers(typeof value === 'string' ? value.split(',') : value);
+  };
+
   // Create new room
   const handleCreateRoom = () => {
     if (!newRoomData.name.trim()) {
@@ -272,7 +288,7 @@ const ProjectChat = ({ projectId }) => {
       return;
     }
 
-    if (selectedQcAdmins.length === 0) {
+    if (selectedQcAdmins.length === 0 && user.role !== 'qcadmin') {
       toast.error('At least one QC Admin must be selected');
       return;
     }
@@ -280,7 +296,7 @@ const ProjectChat = ({ projectId }) => {
     const roomData = {
       ...newRoomData,
       projectId,
-      members: [user._id, ...selectedQcAdmins]
+      members: [...new Set([user._id, ...selectedQcAdmins, ...selectedMembers])]
     };
 
     createRoomMutation.mutate(roomData);
@@ -291,6 +307,7 @@ const ProjectChat = ({ projectId }) => {
     setCreateRoomDialog(false);
     setNewRoomData({ name: '', description: '', isPrivate: false });
     setSelectedQcAdmins([]);
+    setSelectedMembers([]);
   };
 
   // Get user status
@@ -666,6 +683,54 @@ const ProjectChat = ({ projectId }) => {
               </Select>
             </FormControl>
 
+            {/* Additional Members Selection Dropdown */}
+            <FormControl fullWidth sx={{ mt: 2 }}>
+              <InputLabel id="member-select-label">Add Members</InputLabel>
+              <Select
+                labelId="member-select-label"
+                id="member-select"
+                multiple
+                value={selectedMembers}
+                onChange={handleMemberChange}
+                input={<OutlinedInput label="Add Members" />}
+                renderValue={(selected) => (
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                    {selected.map((value) => {
+                      const member = otherMembers.find(m => m._id === value);
+                      return (
+                        <Chip
+                          key={value}
+                          label={member?.name || 'Unknown User'}
+                          size="small"
+                          avatar={<Avatar src={member?.avatar} sx={{ width: 24, height: 24 }} />}
+                        />
+                      );
+                    })}
+                  </Box>
+                )}
+                MenuProps={MenuProps}
+              >
+                {otherMembers.map((member) => (
+                  <MenuItem key={member._id} value={member._id}>
+                    <Checkbox checked={selectedMembers.indexOf(member._id) > -1} />
+                    <Stack direction="row" alignItems="center" spacing={1} sx={{ width: '100%' }}>
+                      <Avatar
+                        src={member.avatar}
+                        alt={member.name}
+                        sx={{ width: 32, height: 32 }}
+                      />
+                      <Stack>
+                        <Typography variant="body2">{member.name}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {member.email}
+                        </Typography>
+                      </Stack>
+                    </Stack>
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
             {qcAdmins.length === 0 && (
               <Alert severity="warning">
                 No QC Admins found for this project. Please add QC Admins to the project first.
@@ -675,6 +740,12 @@ const ProjectChat = ({ projectId }) => {
             {selectedQcAdmins.length > 0 && (
               <Alert severity="info">
                 {selectedQcAdmins.length} QC Admin{selectedQcAdmins.length > 1 ? 's' : ''} selected for this room.
+              </Alert>
+            )}
+
+            {selectedMembers.length > 0 && (
+              <Alert severity="info">
+                {selectedMembers.length} additional member{selectedMembers.length > 1 ? 's' : ''} selected.
               </Alert>
             )}
           </Stack>

--- a/src/Pages/Dashboard/AddProjects/Teams/index.jsx
+++ b/src/Pages/Dashboard/AddProjects/Teams/index.jsx
@@ -11,17 +11,17 @@ import {
   TableRow, TableHead,
   TableCell, TableBody,
   Button, TableContainer,
+  FormControl, Select,
 } from "@mui/material";
 
 
 import { Link, Outlet, useLocation, useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "react-toastify";
 
-
-import { getUserForSubTask } from "../../../../api/userSubTask";
-import { usePromoteUser } from "../../../../hooks/useAuth";
+import { getProjectMembers, assignProjectRole } from "../../../../api/projectRoles";
+import { getCompanyUsers } from "../../../../api/authApi";
 import { useAuth } from "../../../../context/AuthProvider";
 import { usersTimeProject } from "../../../../api/userTracker";
 import { RouteNames } from "../../../../Constants/route";
@@ -34,35 +34,67 @@ export default function Teams() {
   const tableClassText = mode === 'light' ? 'lightTableText' : 'darkTableText';
 
   const { id: projectId } = useParams();
-  // const [_, setUserRole] = useState(null);
   const [anchorEl, setAnchorEl] = useState(null);
+  const [selectedMember, setSelectedMember] = useState(null);
+  const queryClient = useQueryClient();
 
-
-  const handleMenuClick = (event, userId) => {
+  const handleMenuClick = (event, memberId) => {
     setAnchorEl(event.currentTarget);
-    // setUserRole(userId)
+    setSelectedMember(memberId);
   };
 
-
-  const { data: getUserInfo } = useQuery({
-    queryKey: ['assignedUsers', projectId],
-    queryFn: () => getUserForSubTask(projectId),
+  const { data: membersRes } = useQuery({
+    queryKey: ['projectMembers', projectId],
+    queryFn: () => getProjectMembers(projectId),
     enabled: !!projectId,
   });
-  const userData = getUserInfo?.data;
-  const QcAdmins = userData?.filter((user) => user.role === "QcAdmin") || [];
-  const Users = userData?.filter((user) => user.role === "user") || [];
-  // console.log("Users ok", Users)
+  const members = membersRes?.data || [];
+  const QcAdmins = members
+    .filter((m) => m.role === 'qcadmin')
+    .map((m) => ({ ...m.userId, id: m.userId._id, userId: m.userId.name, role: 'qcadmin' }));
+  const Users = members
+    .filter((m) => m.role === 'user')
+    .map((m) => ({ ...m.userId, id: m.userId._id, userId: m.userId.name, role: 'user' }));
 
-  const { mutate: promoteUser } = usePromoteUser();
-  const handlePromoteUser = (userId) => {
-    promoteUser({ userId });
+  const { data: companyUsersRes } = useQuery({
+    queryKey: ['companyUsers'],
+    queryFn: getCompanyUsers,
+    enabled: user?.role === 'company',
+  });
+  const companyUsers = companyUsersRes?.data || [];
+  const existingIds = new Set(members.map((m) => m.userId._id));
+  const availableUsers = companyUsers.filter((u) => !existingIds.has(u._id));
+  const [selectedUser, setSelectedUser] = useState('');
+  const [selectedRole, setSelectedRole] = useState('user');
+
+  const mutation = useMutation({
+    mutationFn: assignProjectRole,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['projectMembers', projectId]);
+      toast.success('Member updated', { position: 'top-center', autoClose: 2000, hideProgressBar: false, pauseOnHover: false });
+    },
+    onError: (err) => {
+      toast.error(err?.response?.data?.message || 'Action failed', { position: 'top-center', autoClose: 2000, hideProgressBar: false, pauseOnHover: false });
+    }
+  });
+
+  const handleAddMember = () => {
+    if (!selectedUser) return;
+    mutation.mutate({ projectId, userId: selectedUser, role: selectedRole });
+    setSelectedUser('');
+    setSelectedRole('user');
+  };
+
+  const handleChangeRole = (role) => {
+    if (!selectedMember) return;
+    mutation.mutate({ projectId, userId: selectedMember, role });
     setAnchorEl(null);
-  }
+    setSelectedMember(null);
+  };
 
   const handleMenuClose = () => {
     setAnchorEl(null);
-    setAnchorEl(null);
+    setSelectedMember(null);
   };
 
 
@@ -82,6 +114,25 @@ export default function Teams() {
     <Stack variant="div" gap={8} my={4}>
       {!isTeamPage && (
         <>
+          {user.role === 'company' && (
+            <Stack direction="row" spacing={2} mb={2}>
+              <FormControl size="small" sx={{ minWidth: 120 }}>
+                <Select value={selectedUser} displayEmpty onChange={(e) => setSelectedUser(e.target.value)}>
+                  <MenuItem value="">Select User</MenuItem>
+                  {availableUsers.map((u) => (
+                    <MenuItem key={u._id} value={u._id}>{u.name}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl size="small" sx={{ minWidth: 120 }}>
+                <Select value={selectedRole} onChange={(e) => setSelectedRole(e.target.value)}>
+                  <MenuItem value="user">User</MenuItem>
+                  <MenuItem value="qcadmin">QC Admin</MenuItem>
+                </Select>
+              </FormControl>
+              <Button variant="outlined" onClick={handleAddMember}>Add</Button>
+            </Stack>
+          )}
           <Box>
             <Typography variant="h6" mb={1} className={tableClassText}>
               Team: (QcAdmin)
@@ -91,24 +142,22 @@ export default function Teams() {
               <Grid container spacing={3} ml="1px">
                 {QcAdmins?.map((person, index) => (
                   <Stack key={index} className={`${style.boxDropDown}`} sx={{ alignItems: 'center' }}>
-
                     <Grid item className={style.gridBox}>
                       <Avatar alt={person.name} src={person.avatar} sx={{ width: 55, height: 55 }} />
                       <Typography variant="body2" align="center" sx={{ marginTop: 1, fontSize: '0.8rem', textAlign: 'center' }}>
                         {person.userId}
                       </Typography>
 
-                      {person.role === "QcAdmin" ? (
+                      {person.role === "qcadmin" ? (
                         <Typography className={style.QC}>QC</Typography>
                       ) : (
-                        <IconButton onClick={(event) => handleMenuClick(event, person)}
+                        <IconButton onClick={(event) => handleMenuClick(event, person.id)}
                           className={style.iconButton}>
                           <MoreVertIcon />
                         </IconButton>
                       )}
                     </Grid>
                   </Stack>
-
                 ))}
               </Grid>
             ) : (
@@ -142,7 +191,7 @@ export default function Teams() {
                       ) : null}
 
                       <IconButton
-                        onClick={(event) => handleMenuClick(event, person)}
+                        onClick={(event) => handleMenuClick(event, person.id)}
                         className={style.iconButton}>
                         <MoreVertIcon />
                       </IconButton>
@@ -158,17 +207,7 @@ export default function Teams() {
                         horizontal: 'right',
                       }} classes={{ paper: style.dropdown }}>
 
-                      <MenuItem onClick={() => handlePromoteUser(person.id,
-                        toast.success(`${person.userId} Successfully Promoted to QCAdmin`, {
-                          position: "top-center",
-                          autoClose: 2000,
-                          hideProgressBar: false,
-                          closeOnClick: true,
-                          pauseOnHover: false,
-                          draggable: true,
-                          progress: false,
-                        })
-                      )} className={style.boxMenuItem}>Promote to QC</MenuItem>
+                      <MenuItem onClick={() => handleChangeRole('qcadmin')} className={style.boxMenuItem}>Promote to QC</MenuItem>
                     </Menu>
                   </Stack>
 

--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -11,6 +11,12 @@ export const getChatRooms = async (projectId) => {
   return data;
 };
 
+// Fetch users associated with a project for room creation
+export const getProjectUsers = async (projectId) => {
+  const { data } = await axiosInstance.get(`/chat/rooms/${projectId}/users`);
+  return data;
+};
+
 export const updateChatRoom = async (roomId, data) => {
   const { data: res } = await axiosInstance.put(`/chat/rooms/${roomId}`, data);
   return res;

--- a/src/api/projectRoles.js
+++ b/src/api/projectRoles.js
@@ -1,0 +1,16 @@
+import { axiosInstance } from './axiosInstance';
+
+export const getProjectMembers = async (projectId) => {
+  const res = await axiosInstance.get(`/user/project-roles/${projectId}`);
+  return res.data;
+};
+
+export const assignProjectRole = async ({ projectId, userId, role }) => {
+  const res = await axiosInstance.post(`/user/project-roles/${projectId}`, { userId, role });
+  return res.data;
+};
+
+export const removeProjectMember = async ({ projectId, userId }) => {
+  const res = await axiosInstance.delete(`/user/project-roles/${projectId}/${userId}`);
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- add controller and routes to assign project-specific roles to members
- expose API helpers and update team page UI to add or promote project members
- allow chat rooms to include QC admins and other project members via updated project user lookup
- prevent chat room member select from closing dialog by keeping its menu inside the modal

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 274 problems)


------
https://chatgpt.com/codex/tasks/task_e_68b9312da18083239cf61bf709d05c3b