### PR TITLE
feat: restrict chat members to project company

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -47,6 +47,7 @@ import userSubTask from "./routes/userSubTask.js";
 import videosPdfSubTask from "./routes/videos&PdfSubTask.js";
 import screenRecordingRoutes from "./routes/screenRecordingRoutes.js";
 import notificationRoute from "./routes/notificationRoute.js";
+import projectRoleRoute from "./routes/projectRoles.js";
 
 import PlanRoute from "./adminPanel/routes/planRoute.js";
 import SuperAdminAuth from "./adminPanel/routes/superAdminAuth.js";
@@ -60,6 +61,7 @@ app.use("/user", userTracker);
 app.use("/user", cloudinaryScreenCapture);
 app.use("/user", userSubTask);
 app.use("/user", videosPdfSubTask);
+app.use("/user/project-roles", projectRoleRoute);
 app.use("/company", screenRecordingRoutes);
 app.use("/notifications", notificationRoute);
 

--- a/server/src/controllers/project.js
+++ b/server/src/controllers/project.js
@@ -1,6 +1,5 @@
 import mongoose from "mongoose";
 import { User } from "../models/userModel.js";
-import { adminTask } from "../models/adminTask.js";
 import { apiError } from "../utils/apiError.js";
 import { apiResponse } from "../utils/apiResponse.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
@@ -24,7 +23,7 @@ const getUserCompanyId = (user) => {
 
 // Helper function to validate project belongs to company
 const validateProjectCompany = async (projectId, companyId) => {
-    const project = await adminTask.findOne({ _id: projectId, companyId });
+    const project = await Project.findOne({ _id: projectId, companyId });
     if (!project) {
         throw new apiError(403, "Project not found or access denied");
     }

--- a/server/src/controllers/projectRoleController.js
+++ b/server/src/controllers/projectRoleController.js
@@ -1,0 +1,62 @@
+import mongoose from 'mongoose';
+import { asyncHandler } from '../utils/asyncHandler.js';
+import { apiResponse } from '../utils/apiResponse.js';
+import { apiError } from '../utils/apiError.js';
+import ProjectRole from '../models/projectRole.js';
+import { Project } from '../models/project.js';
+import { User } from '../models/userModel.js';
+import { ROLES } from '../config/roles.js';
+
+// helper to get companyId from user
+const getUserCompanyId = (user) => {
+  if (user.role === ROLES.COMPANY) return user._id;
+  if ((user.role === ROLES.USER || user.role === ROLES.QCADMIN) && user.companyId) return user.companyId;
+  return null;
+};
+
+// Ensure project belongs to company
+const validateProjectCompany = async (projectId, companyId) => {
+  const project = await Project.findOne({ _id: projectId, companyId });
+  if (!project) throw new apiError(403, 'Project not found or access denied');
+  return project;
+};
+
+// List members for a project
+const listProjectMembers = asyncHandler(async (req, res) => {
+  const { projectId } = req.params;
+  const companyId = getUserCompanyId(req.user);
+  if (!mongoose.isValidObjectId(projectId)) throw new apiError(400, 'Invalid projectId');
+  if (!companyId) throw new apiError(400, 'Company context required');
+  await validateProjectCompany(projectId, companyId);
+  const roles = await ProjectRole.find({ projectId, isActive: true }).populate('userId', 'name avatar role');
+  return res.status(200).json(new apiResponse(200, roles, 'Project members fetched'));
+});
+
+// Assign or update role for a member in a project
+const assignProjectRole = asyncHandler(async (req, res) => {
+  const { projectId } = req.params;
+  const { userId, role } = req.body;
+  const companyId = getUserCompanyId(req.user);
+  if (!projectId || !userId || !role) throw new apiError(400, 'projectId, userId and role are required');
+  if (!Object.values(ROLES).includes(role)) throw new apiError(400, 'Invalid role');
+  await validateProjectCompany(projectId, companyId);
+  const user = await User.findOne({ _id: userId, $or: [{ _id: companyId }, { companyId }] });
+  if (!user) throw new apiError(404, 'User not found in your company');
+  const pr = await ProjectRole.findOneAndUpdate(
+    { projectId, userId },
+    { role, isActive: true },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+  return res.status(200).json(new apiResponse(200, pr, 'Role assigned'));
+});
+
+// Remove member from project
+const removeProjectMember = asyncHandler(async (req, res) => {
+  const { projectId, userId } = req.params;
+  const companyId = getUserCompanyId(req.user);
+  await validateProjectCompany(projectId, companyId);
+  await ProjectRole.findOneAndUpdate({ projectId, userId }, { isActive: false });
+  return res.status(200).json(new apiResponse(200, null, 'Member removed'));
+});
+
+export { listProjectMembers, assignProjectRole, removeProjectMember };

--- a/server/src/controllers/screenRecordingController.js
+++ b/server/src/controllers/screenRecordingController.js
@@ -1,6 +1,6 @@
 import { Recording } from "../models/recordingModel.js";
 import { User } from "../models/userModel.js";
-import { adminTask } from "../models/adminTask.js";
+import { Project } from "../models/project.js";
 import { apiError } from "../utils/apiError.js";
 import { apiResponse } from "../utils/apiResponse.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
@@ -46,7 +46,7 @@ const startRecordingSession = asyncHandler(async (req, res) => {
 
     // Validate associated task if provided
     if (associatedTask) {
-        const task = await adminTask.findOne({
+        const task = await Project.findOne({
             _id: associatedTask,
             companyId: companyId,
         });

--- a/server/src/controllers/subUserTask.js
+++ b/server/src/controllers/subUserTask.js
@@ -1,6 +1,6 @@
 import mongoose from "mongoose";
 import { User } from "../models/userModel.js";
-import { adminTask } from "../models/adminTask.js";
+import { Project } from "../models/project.js";
 import { apiError } from "../utils/apiError.js";
 import { apiResponse } from "../utils/apiResponse.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
@@ -24,7 +24,7 @@ const getUserCompanyId = (user) => {
 
 // Helper function to validate project belongs to company
 const validateProjectCompany = async (projectId, companyId) => {
-    const project = await adminTask.findOne({ _id: projectId, companyId });
+    const project = await Project.findOne({ _id: projectId, companyId });
     if (!project) {
         throw new apiError(403, "Project not found or access denied");
     }

--- a/server/src/controllers/trackerTime.js
+++ b/server/src/controllers/trackerTime.js
@@ -2,7 +2,7 @@ import { apiError } from "../utils/apiError.js";
 import { apiResponse } from "../utils/apiResponse.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
 import { userTracker } from "../models/TrackerTime.js";
-import { adminTask } from "../models/adminTask.js";
+import { Project } from "../models/project.js";
 import { ROLES } from "../config/roles.js";
 import moment from "moment";
 import mongoose from "mongoose";
@@ -32,7 +32,7 @@ const validateProjectCompany = async (projectId, companyId) => {
         return cached.project;
     }
 
-    const project = await adminTask
+    const project = await Project
         .findOne({ _id: projectId, companyId }, "projectTitle")
         .lean();
     if (!project) {
@@ -618,7 +618,8 @@ const getCompanyDashboard = asyncHandler(async (req, res) => {
         },
         {
             $lookup: {
-                from: "usertasks",
+                // Projects collection now backs the time tracking
+                from: "projects",
                 localField: "_id",
                 foreignField: "_id",
                 as: "project",
@@ -628,7 +629,7 @@ const getCompanyDashboard = asyncHandler(async (req, res) => {
         {
             $project: {
                 projectId: "$_id",
-                projectTitle: "$project.projectTitle",
+                projectTitle: "$project.title",
                 totalTime: 1,
                 totalSessions: 1,
                 uniqueUsersCount: { $size: "$uniqueUsers" },

--- a/server/src/models/ChatMessage.js
+++ b/server/src/models/ChatMessage.js
@@ -8,7 +8,7 @@ const chatMessageSchema = new mongoose.Schema({
   },
   senderId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true
   },
   senderName: {
@@ -61,7 +61,7 @@ const chatMessageSchema = new mongoose.Schema({
   reactions: [{
     userId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+        ref: 'UserInfo'
     },
     emoji: String,
     createdAt: {
@@ -72,7 +72,7 @@ const chatMessageSchema = new mongoose.Schema({
   readBy: [{
     userId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+      ref: 'UserInfo'
     },
     readAt: {
       type: Date,
@@ -100,7 +100,7 @@ export const ChatMessage = mongoose.model('ChatMessage', chatMessageSchema);
 const userStatusSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+      ref: 'UserInfo',
     required: true,
     unique: true
   },

--- a/server/src/models/ChatRoom.js
+++ b/server/src/models/ChatRoom.js
@@ -19,16 +19,16 @@ const chatRoomSchema = new mongoose.Schema({
   },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true
   },
   members: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User'
+    ref: 'UserInfo'
   }],
   admins: [{
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User'
+    ref: 'UserInfo'
   }],
   isPrivate: {
     type: Boolean,
@@ -38,7 +38,7 @@ const chatRoomSchema = new mongoose.Schema({
     content: String,
     senderId: {
       type: mongoose.Schema.Types.ObjectId,
-      ref: 'User'
+      ref: 'UserInfo'
     },
     timestamp: Date
   },

--- a/server/src/models/Docs_SubTask/docs_Subtask.js
+++ b/server/src/models/Docs_SubTask/docs_Subtask.js
@@ -13,7 +13,8 @@ const docsSubTaskSchema = new mongoose.Schema(
         },
         projectId: {
             type: mongoose.Schema.Types.ObjectId,
-            ref: "userTask",
+            // Align with renamed Project model
+            ref: "Project",
             required: true,
         },
         // NEW: Company reference for security

--- a/server/src/models/TrackerTime.js
+++ b/server/src/models/TrackerTime.js
@@ -9,7 +9,8 @@ const TimeTrackingSchema = new Schema(
         },
         projectId: {
             type: mongoose.Schema.Types.ObjectId,
-            ref: "userTask",
+            // Link to the main Project record
+            ref: "Project",
             required: true,
         },
         // NEW: Company reference for security - inherited from parent project
@@ -21,7 +22,8 @@ const TimeTrackingSchema = new Schema(
         // Optional: SubTask reference for more granular tracking
         subTaskId: {
             type: mongoose.Schema.Types.ObjectId,
-            ref: "project",
+            // Reference a specific sub-task
+            ref: "subUserTask",
             default: null,
         },
         employee: {
@@ -192,7 +194,8 @@ TimeTrackingSchema.statics.getCompanyProjectStats = function (
         },
         {
             $lookup: {
-                from: "usertasks",
+                // Match against the projects collection
+                from: "projects",
                 localField: "_id",
                 foreignField: "_id",
                 as: "project",
@@ -202,7 +205,8 @@ TimeTrackingSchema.statics.getCompanyProjectStats = function (
         {
             $project: {
                 projectId: "$_id",
-                projectTitle: "$project.projectTitle",
+                // Use the new title field from the Project model
+                projectTitle: "$project.title",
                 totalTime: 1,
                 totalSessions: 1,
                 uniqueUsersCount: { $size: "$uniqueUsers" },

--- a/server/src/models/UserStatus.js
+++ b/server/src/models/UserStatus.js
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 const userStatusSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true,
     unique: true
   },

--- a/server/src/models/Video_SubTask/uploadSingleVideo.js
+++ b/server/src/models/Video_SubTask/uploadSingleVideo.js
@@ -23,7 +23,7 @@ const uploadVideoSchema = new mongoose.Schema(
         },
         // projectId: {
         //     type: mongoose.Schema.Types.ObjectId,
-        //     ref: "userTask",
+        //     ref: "Project",
         // },
         companyId: {
             type: mongoose.Schema.Types.ObjectId,

--- a/server/src/models/Video_SubTask/video_Subtask.js
+++ b/server/src/models/Video_SubTask/video_Subtask.js
@@ -13,7 +13,7 @@ const videoSubtaskSchema = new mongoose.Schema(
         },
         projectId: {
             type: mongoose.Schema.Types.ObjectId,
-            ref: "userTask",
+            ref: "Project",
             required: true,
         },
         companyId: {

--- a/server/src/models/notificationModel.js
+++ b/server/src/models/notificationModel.js
@@ -76,7 +76,7 @@ const notificationSchema = new mongoose.Schema(
         data: {
             taskId: {
                 type: mongoose.Schema.Types.ObjectId,
-                ref: "userTask",
+                ref: "Project",
                 default: null,
             },
             recordingId: {
@@ -225,7 +225,8 @@ notificationSchema.statics.getNotificationsForUser = function (
 
     return this.find(query)
         .populate("sender", "name avatar role")
-        .populate("data.taskId", "projectTitle description")
+        // Populate using the updated Project fields
+        .populate("data.taskId", "title description")
         .populate("data.recordingId", "title description")
         .sort({ [sortBy]: sortOrder })
         .limit(limit)

--- a/server/src/models/projectRole.js
+++ b/server/src/models/projectRole.js
@@ -9,7 +9,7 @@ const projectRoleSchema = new mongoose.Schema({
   },
   userId: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User',
+    ref: 'UserInfo',
     required: true,
     index: true
   },

--- a/server/src/models/recordingModel.js
+++ b/server/src/models/recordingModel.js
@@ -94,7 +94,8 @@ const recordingSchema = new mongoose.Schema(
         // Task association (optional)
         associatedTask: {
             type: mongoose.Schema.Types.ObjectId,
-            ref: "userTask",
+            // The task model has been renamed to "Project"
+            ref: "Project",
             default: null,
         },
 

--- a/server/src/models/snapShot.js
+++ b/server/src/models/snapShot.js
@@ -10,7 +10,8 @@ const ScreenshotSchema = new mongoose.Schema(
         },
         projectId: {
             type: mongoose.Schema.Types.ObjectId,
-            ref: "userTask",
+            // Updated to the new Project model name
+            ref: "Project",
             required: true,
         },
         userInfo: {

--- a/server/src/models/subUserTask.js
+++ b/server/src/models/subUserTask.js
@@ -42,7 +42,7 @@ const subUsertaskSchema = new mongoose.Schema(
         },
         projectId: {
             type: mongoose.Schema.Types.ObjectId,
-            ref: "userTask",
+            ref: "Project",
             required: true,
         },
         // NEW: Company reference for security - inherited from parent project

--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -3,10 +3,12 @@ import express from 'express';
 import multer from 'multer';
 import ChatRoom from '../models/ChatRoom.js';
 import { ChatMessage, UserStatus } from '../models/ChatMessage.js';
-import { User } from '../models/userModel.js';
+import ProjectRole from '../models/projectRole.js';
+import { Project } from '../models/project.js';
 import { uploadOnCloudinary } from '../utils/cloudinary.js';
 import { extractLinkPreview } from '../utils/linkPreview.js';
 import { verifyUser } from '../middleware/authMiddleware.js';
+import { ROLES } from '../config/roles.js';
 
 const router = express.Router();
 router.use(verifyUser());
@@ -35,11 +37,64 @@ console.log('Chat routes loaded');
 
 // ---------------------- Chat Room Routes ----------------------
 
-// Get all chat rooms for a project
-router.route('/rooms/:projectId').get(async (req, res) => {
-  console.log('User IDddddddddddd:', req);
+// Get all users assigned to a project for selection in chat rooms
+router.route('/rooms/:projectId/users').get(async (req, res) => {
   try {
     const { projectId } = req.params;
+
+    const companyId = req.user.role === ROLES.COMPANY ? req.user._id : req.user.companyId;
+
+    // Ensure the project belongs to the requesting company
+    const project = await Project.findOne({ _id: projectId, companyId });
+    if (!project) {
+      return res.status(403).json({
+        success: false,
+        message: 'Project not found or access denied'
+      });
+    }
+
+    const projectUsers = await ProjectRole.find({ projectId, isActive: true })
+      .populate('userId', 'name avatar email companyId');
+
+    const users = projectUsers
+      .filter(pr => {
+        if (!pr.userId) return false;
+        const userCompany = pr.userId.companyId ? pr.userId.companyId.toString() : pr.userId._id.toString();
+        return userCompany === companyId.toString();
+      })
+      .map(pr => ({
+        _id: pr.userId._id,
+        name: pr.userId.name,
+        avatar: pr.userId.avatar,
+        email: pr.userId.email,
+        role: pr.role
+      }));
+
+    res.status(200).json({ success: true, data: users });
+  } catch (error) {
+    console.error('Get project users error:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to fetch project users',
+      error: error.message
+    });
+  }
+});
+
+// Get all chat rooms for a project
+router.route('/rooms/:projectId').get(async (req, res) => {
+  try {
+    const { projectId } = req.params;
+    const companyId = req.user.role === ROLES.COMPANY ? req.user._id : req.user.companyId;
+
+    // Verify project belongs to company
+    const project = await Project.findOne({ _id: projectId, companyId });
+    if (!project) {
+      return res.status(403).json({
+        success: false,
+        message: 'Project not found or access denied'
+      });
+    }
 
     const rooms = await ChatRoom.find({
       projectId,
@@ -77,13 +132,13 @@ router.route('/rooms/:projectId').get(async (req, res) => {
 router.route('/rooms').post(async (req, res) => {
   try {
     // Extract ALL data from the request body - including members array sent from frontend
-    const { 
-      name, 
-      description, 
-      projectId, 
-      isPrivate = false, 
-      members = [] // This is the members array from your frontend payload
-    } = req.body;
+      const {
+        name,
+        description,
+        projectId,
+        isPrivate = false,
+        members = []
+      } = req.body; // members array supplied by the frontend
     
     console.log("Full request body:", req.body);
     console.log("Members from frontend:", members);
@@ -104,28 +159,85 @@ router.route('/rooms').post(async (req, res) => {
       });
     }
 
-    // Use the members array sent from frontend
+    const companyId = req.user.role === ROLES.COMPANY ? req.user._id : req.user.companyId;
+
+    // Ensure project belongs to the requesting company
+    const project = await Project.findOne({ _id: projectId, companyId });
+    if (!project) {
+      return res.status(403).json({
+        success: false,
+        message: 'Project not found or access denied'
+      });
+    }
+
+    // Use the members array sent from frontend and ensure creator is included
     // Filter out any null/undefined values
     const validMembers = members.filter(memberId => memberId != null);
-    
+
+    if (!validMembers.map(id => id.toString()).includes(req.user._id.toString())) {
+      validMembers.push(req.user._id);
+    }
+
     console.log("Valid members after filtering:", validMembers);
-    
-    // Validate that the member IDs exist in the database
-    const existingUsers = await User.find({ 
-      _id: { $in: validMembers } 
-    }).select('_id name role');
-    
-    console.log("Existing users found:", existingUsers);
-    
-    const existingUserIds = existingUsers.map(user => user._id.toString());
-    
+
+    // Separate members to validate (excluding creator)
+    const membersToCheck = validMembers.filter(id => id.toString() !== req.user._id.toString());
+
+    // Fetch project roles for provided members to ensure they belong to the project and company
+    const projectRoles = await ProjectRole.find({
+      projectId,
+      userId: { $in: validMembers },
+      isActive: true
+    }).populate('userId', 'name avatar role companyId');
+
+    // Filter out users not in the same company
+    const filteredRoles = projectRoles.filter(pr => {
+      if (!pr.userId) return false;
+      const userCompany = pr.userId.companyId ? pr.userId.companyId.toString() : pr.userId._id.toString();
+      return userCompany === companyId.toString();
+    });
+
+    const memberIds = filteredRoles.map(pr => pr.userId._id.toString());
+
+    // Validate non-creator members belong to the project and company
+    const nonCreatorIds = filteredRoles
+      .filter(pr => pr.userId._id.toString() !== req.user._id.toString())
+      .map(pr => pr.userId._id.toString());
+
+    if (nonCreatorIds.length !== membersToCheck.length) {
+      return res.status(403).json({
+        success: false,
+        message: 'All members must belong to your company and be assigned to the project'
+      });
+    }
+
+    // Ensure the creator is included in member list
+    if (!memberIds.includes(req.user._id.toString())) {
+      memberIds.push(req.user._id.toString());
+    }
+
+    // Ensure at least one QC admin is part of the room
+    const hasQcAdmin = filteredRoles.some(pr => pr.role === ROLES.QCADMIN);
+    if (!hasQcAdmin) {
+      return res.status(400).json({
+        success: false,
+        message: 'At least one QC Admin is required in a chat room'
+      });
+    }
+
+    const existingUserIds = [...new Set(memberIds)];
+
+    const adminIds = filteredRoles
+      .filter(pr => pr.role === ROLES.QCADMIN)
+      .map(pr => pr.userId._id.toString());
+
     const chatRoom = new ChatRoom({
       name: name.trim(),
       description: description?.trim() || '',
       projectId,
       createdBy: req.user._id,
-      members: existingUserIds, // Use the members from frontend payload
-      admins: [req.user._id], // You can modify this logic as needed
+      members: existingUserIds, // Use the members from frontend payload filtered by project/company membership
+      admins: [...new Set([req.user._id.toString(), ...adminIds])],
       isPrivate
     });
 
@@ -142,18 +254,53 @@ router.route('/rooms').post(async (req, res) => {
     // Emit socket event
     req.io?.to(`project_${projectId}`).emit('room_created', chatRoom);
 
-    res.status(201).json({
+    return res.status(201).json({
       success: true,
       data: chatRoom,
       message: 'Chat room created successfully'
     });
   } catch (error) {
     console.error('Create chat room error:', error);
-    res.status(500).json({ 
-      success: false, 
-      message: 'Failed to create chat room', 
-      error: error.message 
+    res.status(500).json({
+      success: false,
+      message: 'Failed to create chat room',
+      error: error.message
     });
+  }
+});
+
+// Update a chat room
+router.route('/rooms/:roomId').put(async (req, res) => {
+  try {
+    const { roomId } = req.params;
+    const { name, description } = req.body;
+
+    const room = await ChatRoom.findById(roomId);
+    if (!room) return res.status(404).json({ success: false, message: 'Chat room not found' });
+
+    if (!room.members.some(memberId => memberId.equals(req.user._id))) {
+      return res.status(403).json({ success: false, message: 'Access denied to this chat room' });
+    }
+
+    if (name) room.name = name.trim();
+    if (description !== undefined) room.description = description.trim();
+
+    await room.save();
+
+    req.io?.to(`room_${roomId}`).emit('room_updated', {
+      roomId,
+      name: room.name,
+      description: room.description
+    });
+
+    // Return updated fields so client state stays in sync
+    return res.status(200).json({
+      success: true,
+      data: { name: room.name, description: room.description }
+    });
+  } catch (error) {
+    console.error('Update room error:', error);
+    res.status(500).json({ success: false, message: 'Failed to update room', error: error.message });
   }
 });
 

--- a/server/src/routes/projectRoles.js
+++ b/server/src/routes/projectRoles.js
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { verifyUser } from '../middleware/authMiddleware.js';
+import { ROLES } from '../config/roles.js';
+import { listProjectMembers, assignProjectRole, removeProjectMember } from '../controllers/projectRoleController.js';
+
+const router = Router();
+
+// list members - accessible to company users and project members
+router.get('/:projectId', verifyUser([ROLES.COMPANY, ROLES.QCADMIN, ROLES.USER]), listProjectMembers);
+
+// assign/update role - company only
+router.post('/:projectId', verifyUser([ROLES.COMPANY]), assignProjectRole);
+
+// remove member - company only
+router.delete('/:projectId/:userId', verifyUser([ROLES.COMPANY]), removeProjectMember);
+
+export default router;

--- a/server/src/utils/notificationService.js
+++ b/server/src/utils/notificationService.js
@@ -131,7 +131,7 @@ class NotificationService {
         try {
             // Get task details and notify the assigner
             const task = await mongoose
-                .model("userTask")
+                .model("Project")
                 .findById(taskId)
                 .populate("assignedBy", "_id name");
 
@@ -146,7 +146,8 @@ class NotificationService {
                 companyId,
                 type: "TASK_STATUS_CHANGED",
                 title: "Task Status Updated",
-                message: `Task "${task.projectTitle}" status changed to: ${status}`,
+                // Use the current title field from Project model
+                message: `Task "${task.title}" status changed to: ${status}`,
                 data: { taskId },
                 priority: "medium",
                 actionButton: {
@@ -156,7 +157,7 @@ class NotificationService {
             });
 
             console.log(
-                `📋 Task status change notification sent for task: ${task.projectTitle}`
+                `📋 Task status change notification sent for task: ${task.title}`
             );
         } catch (error) {
             console.error(
@@ -174,12 +175,13 @@ class NotificationService {
     ) {
         try {
             // Get task details and notify assigned users
-            const task = await mongoose.model("userTask").findById(taskId);
+            const task = await mongoose.model("Project").findById(taskId);
             if (!task) return;
 
             // Get assigned user IDs
             const users = await User.find({
-                name: { $in: task.teamLeadName },
+                // teamLeadName is legacy; default to empty array if missing
+                name: { $in: task.teamLeadName || [] },
                 companyId: companyId,
             }).select("_id");
 
@@ -190,8 +192,8 @@ class NotificationService {
                 ? "Task Approved  "
                 : "Task Not Approved  ";
             const message = isApproved
-                ? `Great news! Your task "${task.projectTitle}" has been approved.`
-                : `Your task "${task.projectTitle}" was not approved. Please check for feedback.`;
+                ? `Great news! Your task "${task.title}" has been approved.`
+                : `Your task "${task.title}" was not approved. Please check for feedback.`;
 
             await this.createBulkNotifications({
                 recipients,
@@ -209,7 +211,7 @@ class NotificationService {
             });
 
             console.log(
-                `📋 Task approval notification sent for: ${task.projectTitle}`
+                `📋 Task approval notification sent for: ${task.title}`
             );
         } catch (error) {
             console.error("  Error sending task approval notification:", error);
@@ -218,12 +220,12 @@ class NotificationService {
 
     static async notifyTaskDueSoon(taskId, companyId) {
         try {
-            const task = await mongoose.model("userTask").findById(taskId);
+            const task = await mongoose.model("Project").findById(taskId);
             if (!task) return;
 
             // Get assigned user IDs
             const users = await User.find({
-                name: { $in: task.teamLeadName },
+                name: { $in: task.teamLeadName || [] },
                 companyId: companyId,
             }).select("_id");
 
@@ -234,7 +236,7 @@ class NotificationService {
                 companyId,
                 type: "TASK_DUE_SOON",
                 title: "Task Due Soon ⏰",
-                message: `Reminder: Task "${task.projectTitle}" is due in 24 hours.`,
+                message: `Reminder: Task "${task.title}" is due in 24 hours.`,
                 data: { taskId },
                 priority: "high",
                 actionButton: {
@@ -244,7 +246,7 @@ class NotificationService {
             });
 
             console.log(
-                `📋 Due soon notification sent for: ${task.projectTitle}`
+                `📋 Due soon notification sent for: ${task.title}`
             );
         } catch (error) {
             console.error("  Error sending task due soon notification:", error);

--- a/src/Layout/Topbar/index.jsx
+++ b/src/Layout/Topbar/index.jsx
@@ -77,9 +77,7 @@ export default function TopBar({ title }) {
                     <IconButton onClick={handleThemeToggle} color="inherit">
                         {mode === 'light' ? <DarkModeOutlinedIcon /> : <LightModeOutlinedIcon />}
                     </IconButton>
-                    <IconButton>
-                        <NotificationBell />
-                    </IconButton>
+                    <NotificationBell />
                     <IconButton color="inherit" onClick={() => navigate(`/${RouteNames.HOME}`)}>
                         <HomeOutlinedIcon />
                     </IconButton>

--- a/src/Pages/Dashboard/AddProjects/Chat/index.jsx
+++ b/src/Pages/Dashboard/AddProjects/Chat/index.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable no-unused-vars */
 // src/Pages/Dashboard/AddProjects/Chat/index.jsx
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import {
   Box, Stack, Typography, TextField, IconButton, Button,
   Avatar, Paper, Chip, Dialog, DialogTitle, DialogContent,
   DialogActions, List, ListItem, ListItemAvatar, ListItemText,
-  Badge, Tooltip, Divider, Menu, MenuItem, CircularProgress,
-  Alert, Fab, InputAdornment, FormControl, InputLabel, Select,
-  OutlinedInput, Checkbox, ListItemText as MuiListItemText
+  ListItemIcon, ListItemButton, Badge, Tooltip, Divider, Menu, MenuItem, CircularProgress,
+  Alert, InputAdornment, Checkbox
 } from '@mui/material';
 import {
   Send as SendIcon,
@@ -18,29 +17,26 @@ import {
   Link as LinkIcon,
   Close as CloseIcon,
   Search as SearchIcon,
-  EmojiEmotions as EmojiIcon
+  EmojiEmotions as EmojiIcon,
+  Settings as SettingsIcon,
+  Group as GroupIcon,
+  ExitToApp as ExitToAppIcon
 } from '@mui/icons-material';
 import { useAuth } from '../../../../context/AuthProvider';
 import { useSocket } from '../../../../hooks/useSocket';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
-  createChatRoom, getChatRooms, sendMessage as apiSendMessage,
-  getMessages, uploadChatFile, joinChatRoom as apiJoinChatRoom
+  createChatRoom,
+  getChatRooms,
+  sendMessage as apiSendMessage,
+  getMessages,
+  uploadChatFile,
+  getProjectUsers,
+  updateChatRoom,
+  leaveChatRoom as apiLeaveChatRoom
 } from '../../../../api/chat';
 import { toast } from 'react-toastify';
-import { getUserForSubTask } from '../../../../api/userSubTask';
 import PropTypes from 'prop-types';
-
-const ITEM_HEIGHT = 48;
-const ITEM_PADDING_TOP = 8;
-const MenuProps = {
-  PaperProps: {
-    style: {
-      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-      width: 250,
-    },
-  },
-};
 
 const ProjectChat = ({ projectId }) => {
   const { user, theme, mode } = useAuth();
@@ -53,11 +49,16 @@ const ProjectChat = ({ projectId }) => {
   const [createRoomDialog, setCreateRoomDialog] = useState(false);
   const [newRoomData, setNewRoomData] = useState({ name: '', description: '', isPrivate: false });
   const [selectedQcAdmins, setSelectedQcAdmins] = useState([]);
+  const [selectedMembers, setSelectedMembers] = useState([]);
   const [isTyping, setIsTyping] = useState(false);
   const [typingUsers, setTypingUsers] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFile, setSelectedFile] = useState(null);
   const [anchorEl, setAnchorEl] = useState(null);
+  const [viewMembersOpen, setViewMembersOpen] = useState(false);
+  const [roomSettingsOpen, setRoomSettingsOpen] = useState(false);
+  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
+  const [roomSettingsData, setRoomSettingsData] = useState({ name: '', description: '' });
   
   // Socket connection
   const {
@@ -65,20 +66,29 @@ const ProjectChat = ({ projectId }) => {
     isConnected,
     onlineUsers,
     joinChatRoom,
-    leaveChatRoom,
+    leaveChatRoom: socketLeaveChatRoom,
     sendMessage: socketSendMessage,
-    sendTypingIndicator
+    sendTypingIndicator,
+    updateUserStatus
   } = useSocket(projectId);
 
   // Fetch chat rooms
-  const { data: chatRooms, isLoading: roomsLoading } = useQuery({
+  const {
+    data: chatRooms,
+    isLoading: roomsLoading,
+    error: roomsError
+  } = useQuery({
     queryKey: ['chatRooms', projectId],
     queryFn: () => getChatRooms(projectId),
     enabled: !!projectId
   });
 
   // Fetch messages for selected room
-  const { data: messages, isLoading: messagesLoading } = useQuery({
+  const {
+    data: messages,
+    isLoading: messagesLoading,
+    error: messagesError
+  } = useQuery({
     queryKey: ['messages', selectedRoom?._id],
     queryFn: () => getMessages(selectedRoom._id),
     enabled: !!selectedRoom?._id,
@@ -88,9 +98,27 @@ const ProjectChat = ({ projectId }) => {
   // Fetch project users for room creation
   const { data: projectUsers } = useQuery({
     queryKey: ['projectUsers', projectId],
-    queryFn: () => getUserForSubTask(projectId),
+    queryFn: () => getProjectUsers(projectId),
     enabled: !!projectId
   });
+
+  useEffect(() => {
+    if (!isConnected) return;
+    updateUserStatus('online');
+    return () => updateUserStatus('offline');
+  }, [isConnected, updateUserStatus]);
+
+  useEffect(() => {
+    if (roomsError) {
+      console.error('Get chat rooms error:', roomsError);
+    }
+  }, [roomsError]);
+
+  useEffect(() => {
+    if (messagesError) {
+      console.error('Get messages error:', messagesError);
+    }
+  }, [messagesError]);
 
   // Create room mutation
   const createRoomMutation = useMutation({
@@ -100,6 +128,7 @@ const ProjectChat = ({ projectId }) => {
       setCreateRoomDialog(false);
       setNewRoomData({ name: '', description: '', isPrivate: false });
       setSelectedQcAdmins([]);
+      setSelectedMembers([]);
       setSelectedRoom(data.data);
       toast.success('Chat room created successfully!');
     },
@@ -138,8 +167,60 @@ const ProjectChat = ({ projectId }) => {
       setSelectedFile(null);
     }
   });
-  // Get QC Admins from project users
-  const qcAdmins = projectUsers?.data?.filter(user => user.role === 'qcadmin') || [];
+
+  const updateRoomMutation = useMutation({
+    mutationFn: ({ roomId, data }) => updateChatRoom(roomId, data),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries(['chatRooms', projectId]);
+      setSelectedRoom(prev => ({ ...prev, ...res.data }));
+      setRoomSettingsOpen(false);
+      toast.success('Room updated');
+    },
+    onError: (error) => {
+      toast.error(error?.response?.data?.message || 'Failed to update room');
+    }
+  });
+
+  const leaveRoomMutation = useMutation({
+    mutationFn: apiLeaveChatRoom,
+    onSuccess: () => {
+      socketLeaveChatRoom(selectedRoom._id);
+      setLeaveDialogOpen(false);
+      setSelectedRoom(null);
+      queryClient.invalidateQueries(['chatRooms', projectId]);
+      toast.success('Left the room');
+    },
+    onError: (error) => {
+      toast.error(error?.response?.data?.message || 'Failed to leave room');
+    }
+  });
+  // Separate project users by role
+  const allProjectUsers = useMemo(
+    () => projectUsers?.data?.filter(u => u._id !== user._id) || [],
+    [projectUsers?.data, user._id]
+  );
+  const qcAdmins = useMemo(
+    () => allProjectUsers.filter(u => u.role === 'qcadmin'),
+    [allProjectUsers]
+  );
+  const otherMembers = useMemo(
+    () => allProjectUsers.filter(u => u.role !== 'qcadmin'),
+    [allProjectUsers]
+  );
+
+  const roomMembers = useMemo(() => {
+    if (!selectedRoom) return [];
+    const map = new Map((projectUsers?.data || []).map(u => [u._id, u]));
+    map.set(user._id, { _id: user._id, name: user.name, avatar: user.avatar, role: user.role });
+    return (selectedRoom.members || []).map(id => map.get(id)).filter(Boolean);
+  }, [selectedRoom, projectUsers?.data, user]);
+
+  const onlineMemberCount = useMemo(() => {
+    if (!selectedRoom) return 0;
+    const memberIds = (selectedRoom.members || []).map(id => id.toString());
+    return onlineUsers.filter(u => memberIds.includes(u.userId)).length;
+    // counts how many room members appear in onlineUsers
+  }, [selectedRoom, onlineUsers]);
 
   // Socket event listeners
   useEffect(() => {
@@ -192,17 +273,26 @@ const ProjectChat = ({ projectId }) => {
   useEffect(() => {
     if (selectedRoom && socket && isConnected) {
       joinChatRoom(selectedRoom._id);
-      return () => leaveChatRoom(selectedRoom._id);
+      return () => socketLeaveChatRoom(selectedRoom._id);
     }
-  }, [selectedRoom, socket, isConnected, joinChatRoom, leaveChatRoom]);
+  }, [selectedRoom, socket, isConnected, joinChatRoom, socketLeaveChatRoom]);
 
-  // Initialize selected QC Admins when dialog opens
+  // Initialize selected members when dialog opens
   useEffect(() => {
     if (createRoomDialog) {
-      // Pre-select all QC Admins by default
-      setSelectedQcAdmins(qcAdmins.map(admin => admin._id));
+      const initialAdmins = user.role === 'qcadmin'
+        ? [user._id, ...qcAdmins.map(admin => admin._id)]
+        : qcAdmins.map(admin => admin._id);
+      setSelectedQcAdmins(initialAdmins);
+      setSelectedMembers([]);
     }
-  }, [createRoomDialog, qcAdmins]);
+  }, [createRoomDialog, qcAdmins, user._id, user.role]);
+
+  useEffect(() => {
+    if (roomSettingsOpen && selectedRoom) {
+      setRoomSettingsData({ name: selectedRoom.name || '', description: selectedRoom.description || '' });
+    }
+  }, [roomSettingsOpen, selectedRoom]);
 
   // Handle send message
   const handleSendMessage = (messageData = null) => {
@@ -213,13 +303,38 @@ const ProjectChat = ({ projectId }) => {
 
     if (!messageToSend.content && messageToSend.type === 'text') return;
 
+    const tempId = `temp-${Date.now()}`;
+    const optimisticMessage = {
+      _id: tempId,
+      roomId: selectedRoom._id,
+      senderId: user._id,
+      senderName: user.name,
+      senderAvatar: user.avatar,
+      createdAt: new Date().toISOString(),
+      ...messageToSend
+    };
+
+    // Optimistically add message to cache
+    queryClient.setQueryData(['messages', selectedRoom._id], old => {
+      const prev = old?.data || [];
+      return { ...old, data: [...prev, optimisticMessage] };
+    });
+
     // Send via socket for real-time
     socketSendMessage(selectedRoom._id, messageToSend);
-    
+
     // Send via API for persistence
     sendMessageMutation.mutate({
       roomId: selectedRoom._id,
       message: messageToSend
+    }, {
+      onError: () => {
+        // Remove optimistic message on failure
+        queryClient.setQueryData(['messages', selectedRoom._id], old => {
+          const prev = old?.data || [];
+          return { ...old, data: prev.filter(m => m._id !== tempId) };
+        });
+      }
     });
 
     if (!messageData) {
@@ -259,10 +374,30 @@ const ProjectChat = ({ projectId }) => {
     uploadFileMutation.mutate({ file, roomId: selectedRoom._id });
   };
 
-  // Handle QC Admin selection change
-  const handleQcAdminChange = (event) => {
-    const value = event.target.value;
-    setSelectedQcAdmins(typeof value === 'string' ? value.split(',') : value);
+  // Toggle QC Admin selection
+  const toggleQcAdmin = (id) => {
+    setSelectedQcAdmins(prev =>
+      prev.includes(id) ? prev.filter(uid => uid !== id) : [...prev, id]
+    );
+  };
+
+  // Toggle additional member selection
+  const toggleMember = (id) => {
+    setSelectedMembers(prev =>
+      prev.includes(id) ? prev.filter(uid => uid !== id) : [...prev, id]
+    );
+  };
+
+  const handleUpdateRoom = () => {
+    if (!roomSettingsData.name.trim()) {
+      toast.error('Room name is required');
+      return;
+    }
+    updateRoomMutation.mutate({ roomId: selectedRoom._id, data: roomSettingsData });
+  };
+
+  const handleLeaveRoom = () => {
+    leaveRoomMutation.mutate(selectedRoom._id);
   };
 
   // Create new room
@@ -272,7 +407,7 @@ const ProjectChat = ({ projectId }) => {
       return;
     }
 
-    if (selectedQcAdmins.length === 0) {
+    if (selectedQcAdmins.length === 0 && user.role !== 'qcadmin') {
       toast.error('At least one QC Admin must be selected');
       return;
     }
@@ -280,7 +415,7 @@ const ProjectChat = ({ projectId }) => {
     const roomData = {
       ...newRoomData,
       projectId,
-      members: [user._id, ...selectedQcAdmins]
+      members: [...new Set([user._id, ...selectedQcAdmins, ...selectedMembers])]
     };
 
     createRoomMutation.mutate(roomData);
@@ -291,11 +426,12 @@ const ProjectChat = ({ projectId }) => {
     setCreateRoomDialog(false);
     setNewRoomData({ name: '', description: '', isPrivate: false });
     setSelectedQcAdmins([]);
+    setSelectedMembers([]);
   };
 
   // Get user status
   const getUserStatus = (userId) => {
-    return onlineUsers.find(u => u.userId === userId) ? 'online' : 'offline';
+    return onlineUsers.some(u => u.userId === userId?.toString()) ? 'online' : 'offline';
   };
 
   // Format message time
@@ -319,17 +455,19 @@ const ProjectChat = ({ projectId }) => {
 
   const styles = {
     container: {
-      height: '600px',
+      height: '70vh',
       backgroundColor: theme.palette.background.paper,
-      borderRadius: '8px',
+      borderRadius: 2,
+      boxShadow: theme.shadows[3],
       overflow: 'hidden',
       display: 'flex'
     },
     sidebar: {
-      width: '300px',
+      width: 300,
       borderRight: `1px solid ${theme.palette.divider}`,
       display: 'flex',
-      flexDirection: 'column'
+      flexDirection: 'column',
+      backgroundColor: theme.palette.background.default
     },
     chatArea: {
       flex: 1,
@@ -339,11 +477,11 @@ const ProjectChat = ({ projectId }) => {
     messageArea: {
       flex: 1,
       overflow: 'auto',
-      padding: '16px',
+      padding: 2,
       backgroundColor: theme.palette.background.default
     },
     inputArea: {
-      padding: '16px',
+      p: 2,
       borderTop: `1px solid ${theme.palette.divider}`,
       backgroundColor: theme.palette.background.paper
     }
@@ -380,7 +518,7 @@ const ProjectChat = ({ projectId }) => {
             Online ({onlineUsers.length})
           </Typography>
           <Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>
-            {onlineUsers.map(onlineUser => (
+            {onlineUsers?.map(onlineUser => (
               <Tooltip key={onlineUser.userId} title={onlineUser.userName}>
                 <Badge
                   color="success"
@@ -407,33 +545,37 @@ const ProjectChat = ({ projectId }) => {
             <Box display="flex" justifyContent="center" p={3}>
               <CircularProgress size={24} />
             </Box>
+          ) : roomsError ? (
+            <Box p={2}>
+              <Alert severity="error">Failed to load chat rooms</Alert>
+            </Box>
           ) : (
             <List>
               {chatRooms?.data?.map(room => (
-                <ListItem
-                  key={room._id}
-                  button
-                  selected={selectedRoom?._id === room._id}
-                  onClick={() => setSelectedRoom(room)}
-                >
-                  <ListItemAvatar>
-                    <Avatar sx={{ bgcolor: theme.palette.primary.main }}>
-                      {room.name.charAt(0).toUpperCase()}
-                    </Avatar>
-                  </ListItemAvatar>
-                  <ListItemText
-                    primary={room.name}
-                    secondary={room.description}
-                    primaryTypographyProps={{ noWrap: true }}
-                    secondaryTypographyProps={{ noWrap: true }}
-                  />
-                  {room.unreadCount > 0 && (
-                    <Chip
-                      size="small"
-                      color="primary"
-                      label={room.unreadCount}
+                <ListItem key={room._id} disablePadding>
+                  <ListItemButton
+                    selected={selectedRoom?._id === room._id}
+                    onClick={() => setSelectedRoom(room)}
+                  >
+                    <ListItemAvatar>
+                      <Avatar sx={{ bgcolor: theme.palette.primary.main }}>
+                        {room.name.charAt(0).toUpperCase()}
+                      </Avatar>
+                    </ListItemAvatar>
+                    <ListItemText
+                      primary={room.name}
+                      secondary={room.description}
+                      primaryTypographyProps={{ noWrap: true }}
+                      secondaryTypographyProps={{ noWrap: true }}
                     />
-                  )}
+                    {room.unreadCount > 0 && (
+                      <Chip
+                        size="small"
+                        color="primary"
+                        label={room.unreadCount}
+                      />
+                    )}
+                  </ListItemButton>
                 </ListItem>
               ))}
             </List>
@@ -456,7 +598,7 @@ const ProjectChat = ({ projectId }) => {
               <Stack>
                 <Typography variant="h6">{selectedRoom.name}</Typography>
                 <Typography variant="caption" color="text.secondary">
-                  {selectedRoom.members?.length} members
+                  {selectedRoom.members?.length} members, {onlineMemberCount} online
                 </Typography>
               </Stack>
               
@@ -487,6 +629,10 @@ const ProjectChat = ({ projectId }) => {
                 <Box display="flex" justifyContent="center" p={3}>
                   <CircularProgress />
                 </Box>
+              ) : messagesError ? (
+                <Box p={2}>
+                  <Alert severity="error">Failed to load messages</Alert>
+                </Box>
               ) : (
                 <Stack spacing={1}>
                   {filteredMessages.map(message => (
@@ -498,7 +644,7 @@ const ProjectChat = ({ projectId }) => {
                       formatTime={formatMessageTime}
                     />
                   ))}
-                  
+
                   {/* Typing Indicator */}
                   {typingUsers.length > 0 && (
                     <Box>
@@ -507,7 +653,7 @@ const ProjectChat = ({ projectId }) => {
                       </Typography>
                     </Box>
                   )}
-                  
+
                   <div ref={messagesEndRef} />
                 </Stack>
               )}
@@ -618,53 +764,45 @@ const ProjectChat = ({ projectId }) => {
               placeholder="Brief description of the room purpose"
             />
             
-            {/* QC Admin Selection Dropdown */}
-            <FormControl fullWidth>
-              <InputLabel id="qc-admin-select-label">Select QC Admins</InputLabel>
-              <Select
-                labelId="qc-admin-select-label"
-                id="qc-admin-select"
-                multiple
-                value={selectedQcAdmins}
-                onChange={handleQcAdminChange}
-                input={<OutlinedInput label="Select QC Admins" />}
-                renderValue={(selected) => (
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                    {selected.map((value) => {
-                      const admin = qcAdmins.find(admin => admin._id === value);
-                      return (
-                        <Chip 
-                          key={value} 
-                          label={admin?.name || 'Unknown Admin'} 
-                          size="small"
-                          avatar={<Avatar src={admin?.avatar} sx={{ width: 24, height: 24 }} />}
-                        />
-                      );
-                    })}
-                  </Box>
-                )}
-                MenuProps={MenuProps}
-              >
-                {qcAdmins.map((admin) => (
-                  <MenuItem key={admin._id} value={admin._id}>
-                    <Checkbox checked={selectedQcAdmins.indexOf(admin._id) > -1} />
-                    <Stack direction="row" alignItems="center" spacing={1} sx={{ width: '100%' }}>
-                      <Avatar 
-                        src={admin.avatar} 
-                        alt={admin.name}
-                        sx={{ width: 32, height: 32 }}
-                      />
-                      <Stack>
-                        <Typography variant="body2">{admin.name}</Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          {admin.email}
-                        </Typography>
-                      </Stack>
-                    </Stack>
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            {/* QC Admin Selection */}
+            <Typography variant="subtitle2" sx={{ mt: 2 }}>QC Admins</Typography>
+            <List dense>
+              {qcAdmins.map((admin) => (
+                <ListItem key={admin._id} disablePadding>
+                  <Checkbox
+                    edge="start"
+                    checked={selectedQcAdmins.includes(admin._id)}
+                    onChange={() => toggleQcAdmin(admin._id)}
+                    tabIndex={-1}
+                    disableRipple
+                  />
+                  <ListItemAvatar>
+                    <Avatar src={admin.avatar} alt={admin.name} sx={{ width: 32, height: 32 }} />
+                  </ListItemAvatar>
+                  <ListItemText primary={admin.name} secondary={admin.email} />
+                </ListItem>
+              ))}
+            </List>
+
+            {/* Additional Members Selection */}
+            <Typography variant="subtitle2" sx={{ mt: 2 }}>Add Members</Typography>
+            <List dense>
+              {otherMembers.map((member) => (
+                <ListItem key={member._id} disablePadding>
+                  <Checkbox
+                    edge="start"
+                    checked={selectedMembers.includes(member._id)}
+                    onChange={() => toggleMember(member._id)}
+                    tabIndex={-1}
+                    disableRipple
+                  />
+                  <ListItemAvatar>
+                    <Avatar src={member.avatar} alt={member.name} sx={{ width: 32, height: 32 }} />
+                  </ListItemAvatar>
+                  <ListItemText primary={member.name} secondary={member.email} />
+                </ListItem>
+              ))}
+            </List>
 
             {qcAdmins.length === 0 && (
               <Alert severity="warning">
@@ -675,6 +813,12 @@ const ProjectChat = ({ projectId }) => {
             {selectedQcAdmins.length > 0 && (
               <Alert severity="info">
                 {selectedQcAdmins.length} QC Admin{selectedQcAdmins.length > 1 ? 's' : ''} selected for this room.
+              </Alert>
+            )}
+
+            {selectedMembers.length > 0 && (
+              <Alert severity="info">
+                {selectedMembers.length} additional member{selectedMembers.length > 1 ? 's' : ''} selected.
               </Alert>
             )}
           </Stack>
@@ -697,24 +841,89 @@ const ProjectChat = ({ projectId }) => {
         open={Boolean(anchorEl)}
         onClose={() => setAnchorEl(null)}
       >
-        <MenuItem onClick={() => setAnchorEl(null)}>
+        <MenuItem onClick={() => { setRoomSettingsOpen(true); setAnchorEl(null); }}>
+          <ListItemIcon><SettingsIcon fontSize="small" /></ListItemIcon>
           Room Settings
         </MenuItem>
-        <MenuItem onClick={() => setAnchorEl(null)}>
+        <MenuItem onClick={() => { setViewMembersOpen(true); setAnchorEl(null); }}>
+          <ListItemIcon><GroupIcon fontSize="small" /></ListItemIcon>
           View Members
         </MenuItem>
-        <MenuItem onClick={() => setAnchorEl(null)}>
+        <MenuItem onClick={() => { setLeaveDialogOpen(true); setAnchorEl(null); }}>
+          <ListItemIcon><ExitToAppIcon fontSize="small" /></ListItemIcon>
           Leave Room
         </MenuItem>
       </Menu>
+
+      {/* View Members Dialog */}
+      <Dialog open={viewMembersOpen} onClose={() => setViewMembersOpen(false)} fullWidth>
+        <DialogTitle>Room Members</DialogTitle>
+        <List>
+          {roomMembers.map(member => (
+            <ListItem key={member._id}>
+              <ListItemAvatar>
+                <Badge
+                  color={getUserStatus(member._id) === 'online' ? 'success' : 'default'}
+                  variant="dot"
+                  overlap="circular"
+                  anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                >
+                  <Avatar src={member.avatar} alt={member.name} />
+                </Badge>
+              </ListItemAvatar>
+              <ListItemText primary={member.name} secondary={member.role === 'qcadmin' ? 'QC Admin' : 'Member'} />
+            </ListItem>
+          ))}
+        </List>
+      </Dialog>
+
+      {/* Room Settings Dialog */}
+      <Dialog open={roomSettingsOpen} onClose={() => setRoomSettingsOpen(false)} fullWidth>
+        <DialogTitle>Room Settings</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Room Name"
+              value={roomSettingsData.name}
+              onChange={(e) => setRoomSettingsData({ ...roomSettingsData, name: e.target.value })}
+              fullWidth
+            />
+            <TextField
+              label="Description"
+              value={roomSettingsData.description}
+              onChange={(e) => setRoomSettingsData({ ...roomSettingsData, description: e.target.value })}
+              multiline
+              rows={3}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRoomSettingsOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleUpdateRoom} disabled={updateRoomMutation.isLoading}>
+            {updateRoomMutation.isLoading ? <CircularProgress size={20} /> : 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Leave Room Confirmation */}
+      <Dialog open={leaveDialogOpen} onClose={() => setLeaveDialogOpen(false)}>
+        <DialogTitle>Leave this room?</DialogTitle>
+        <DialogActions>
+          <Button onClick={() => setLeaveDialogOpen(false)}>Cancel</Button>
+          <Button color="error" variant="contained" onClick={handleLeaveRoom} disabled={leaveRoomMutation.isLoading}>
+            {leaveRoomMutation.isLoading ? <CircularProgress size={20} /> : 'Leave'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };
 
 // Message Bubble Component
 const MessageBubble = ({ message, isOwn, onlineStatus, formatTime }) => {
-  const { theme } = useAuth();
-  
+  const { theme, mode } = useAuth();
+
   const bubbleStyles = {
     alignSelf: isOwn ? 'flex-end' : 'flex-start',
     maxWidth: '70%',
@@ -722,8 +931,12 @@ const MessageBubble = ({ message, isOwn, onlineStatus, formatTime }) => {
   };
 
   const contentStyles = {
-    backgroundColor: isOwn ? theme.palette.primary.main : theme.palette.background.paper,
-    color: isOwn ? theme.palette.primary.contrastText : theme.palette.text.primary,
+    backgroundColor: isOwn
+      ? (mode === 'light' ? '#dcf8c6' : theme.palette.primary.dark)
+      : (mode === 'light' ? theme.palette.background.paper : theme.palette.grey[700]),
+    color: isOwn
+      ? (mode === 'light' ? theme.palette.text.primary : theme.palette.primary.contrastText)
+      : theme.palette.text.primary,
     padding: '8px 12px',
     borderRadius: isOwn ? '18px 18px 4px 18px' : '18px 18px 18px 4px',
     boxShadow: theme.shadows[1]

--- a/src/Pages/Dashboard/AddProjects/Teams/index.jsx
+++ b/src/Pages/Dashboard/AddProjects/Teams/index.jsx
@@ -11,17 +11,17 @@ import {
   TableRow, TableHead,
   TableCell, TableBody,
   Button, TableContainer,
+  FormControl, Select,
 } from "@mui/material";
 
 
 import { Link, Outlet, useLocation, useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "react-toastify";
 
-
-import { getUserForSubTask } from "../../../../api/userSubTask";
-import { usePromoteUser } from "../../../../hooks/useAuth";
+import { getProjectMembers, assignProjectRole } from "../../../../api/projectRoles";
+import { getCompanyUsers } from "../../../../api/authApi";
 import { useAuth } from "../../../../context/AuthProvider";
 import { usersTimeProject } from "../../../../api/userTracker";
 import { RouteNames } from "../../../../Constants/route";
@@ -34,35 +34,67 @@ export default function Teams() {
   const tableClassText = mode === 'light' ? 'lightTableText' : 'darkTableText';
 
   const { id: projectId } = useParams();
-  // const [_, setUserRole] = useState(null);
   const [anchorEl, setAnchorEl] = useState(null);
+  const [selectedMember, setSelectedMember] = useState(null);
+  const queryClient = useQueryClient();
 
-
-  const handleMenuClick = (event, userId) => {
+  const handleMenuClick = (event, memberId) => {
     setAnchorEl(event.currentTarget);
-    // setUserRole(userId)
+    setSelectedMember(memberId);
   };
 
-
-  const { data: getUserInfo } = useQuery({
-    queryKey: ['assignedUsers', projectId],
-    queryFn: () => getUserForSubTask(projectId),
+  const { data: membersRes } = useQuery({
+    queryKey: ['projectMembers', projectId],
+    queryFn: () => getProjectMembers(projectId),
     enabled: !!projectId,
   });
-  const userData = getUserInfo?.data;
-  const QcAdmins = userData?.filter((user) => user.role === "QcAdmin") || [];
-  const Users = userData?.filter((user) => user.role === "user") || [];
-  // console.log("Users ok", Users)
+  const members = membersRes?.data || [];
+  const QcAdmins = members
+    .filter((m) => m.role === 'qcadmin')
+    .map((m) => ({ ...m.userId, id: m.userId._id, userId: m.userId.name, role: 'qcadmin' }));
+  const Users = members
+    .filter((m) => m.role === 'user')
+    .map((m) => ({ ...m.userId, id: m.userId._id, userId: m.userId.name, role: 'user' }));
 
-  const { mutate: promoteUser } = usePromoteUser();
-  const handlePromoteUser = (userId) => {
-    promoteUser({ userId });
+  const { data: companyUsersRes } = useQuery({
+    queryKey: ['companyUsers'],
+    queryFn: getCompanyUsers,
+    enabled: user?.role === 'company',
+  });
+  const companyUsers = companyUsersRes?.data || [];
+  const existingIds = new Set(members.map((m) => m.userId._id));
+  const availableUsers = companyUsers.filter((u) => !existingIds.has(u._id));
+  const [selectedUser, setSelectedUser] = useState('');
+  const [selectedRole, setSelectedRole] = useState('user');
+
+  const mutation = useMutation({
+    mutationFn: assignProjectRole,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['projectMembers', projectId]);
+      toast.success('Member updated', { position: 'top-center', autoClose: 2000, hideProgressBar: false, pauseOnHover: false });
+    },
+    onError: (err) => {
+      toast.error(err?.response?.data?.message || 'Action failed', { position: 'top-center', autoClose: 2000, hideProgressBar: false, pauseOnHover: false });
+    }
+  });
+
+  const handleAddMember = () => {
+    if (!selectedUser) return;
+    mutation.mutate({ projectId, userId: selectedUser, role: selectedRole });
+    setSelectedUser('');
+    setSelectedRole('user');
+  };
+
+  const handleChangeRole = (role) => {
+    if (!selectedMember) return;
+    mutation.mutate({ projectId, userId: selectedMember, role });
     setAnchorEl(null);
-  }
+    setSelectedMember(null);
+  };
 
   const handleMenuClose = () => {
     setAnchorEl(null);
-    setAnchorEl(null);
+    setSelectedMember(null);
   };
 
 
@@ -82,6 +114,25 @@ export default function Teams() {
     <Stack variant="div" gap={8} my={4}>
       {!isTeamPage && (
         <>
+          {user.role === 'company' && (
+            <Stack direction="row" spacing={2} mb={2}>
+              <FormControl size="small" sx={{ minWidth: 120 }}>
+                <Select value={selectedUser} displayEmpty onChange={(e) => setSelectedUser(e.target.value)}>
+                  <MenuItem value="">Select User</MenuItem>
+                  {availableUsers.map((u) => (
+                    <MenuItem key={u._id} value={u._id}>{u.name}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl size="small" sx={{ minWidth: 120 }}>
+                <Select value={selectedRole} onChange={(e) => setSelectedRole(e.target.value)}>
+                  <MenuItem value="user">User</MenuItem>
+                  <MenuItem value="qcadmin">QC Admin</MenuItem>
+                </Select>
+              </FormControl>
+              <Button variant="outlined" onClick={handleAddMember}>Add</Button>
+            </Stack>
+          )}
           <Box>
             <Typography variant="h6" mb={1} className={tableClassText}>
               Team: (QcAdmin)
@@ -91,24 +142,22 @@ export default function Teams() {
               <Grid container spacing={3} ml="1px">
                 {QcAdmins?.map((person, index) => (
                   <Stack key={index} className={`${style.boxDropDown}`} sx={{ alignItems: 'center' }}>
-
                     <Grid item className={style.gridBox}>
                       <Avatar alt={person.name} src={person.avatar} sx={{ width: 55, height: 55 }} />
                       <Typography variant="body2" align="center" sx={{ marginTop: 1, fontSize: '0.8rem', textAlign: 'center' }}>
                         {person.userId}
                       </Typography>
 
-                      {person.role === "QcAdmin" ? (
+                      {person.role === "qcadmin" ? (
                         <Typography className={style.QC}>QC</Typography>
                       ) : (
-                        <IconButton onClick={(event) => handleMenuClick(event, person)}
+                        <IconButton onClick={(event) => handleMenuClick(event, person.id)}
                           className={style.iconButton}>
                           <MoreVertIcon />
                         </IconButton>
                       )}
                     </Grid>
                   </Stack>
-
                 ))}
               </Grid>
             ) : (
@@ -142,7 +191,7 @@ export default function Teams() {
                       ) : null}
 
                       <IconButton
-                        onClick={(event) => handleMenuClick(event, person)}
+                        onClick={(event) => handleMenuClick(event, person.id)}
                         className={style.iconButton}>
                         <MoreVertIcon />
                       </IconButton>
@@ -158,17 +207,7 @@ export default function Teams() {
                         horizontal: 'right',
                       }} classes={{ paper: style.dropdown }}>
 
-                      <MenuItem onClick={() => handlePromoteUser(person.id,
-                        toast.success(`${person.userId} Successfully Promoted to QCAdmin`, {
-                          position: "top-center",
-                          autoClose: 2000,
-                          hideProgressBar: false,
-                          closeOnClick: true,
-                          pauseOnHover: false,
-                          draggable: true,
-                          progress: false,
-                        })
-                      )} className={style.boxMenuItem}>Promote to QC</MenuItem>
+                      <MenuItem onClick={() => handleChangeRole('qcadmin')} className={style.boxMenuItem}>Promote to QC</MenuItem>
                     </Menu>
                   </Stack>
 

--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -11,6 +11,12 @@ export const getChatRooms = async (projectId) => {
   return data;
 };
 
+// Fetch users associated with a project for room creation
+export const getProjectUsers = async (projectId) => {
+  const { data } = await axiosInstance.get(`/chat/rooms/${projectId}/users`);
+  return data;
+};
+
 export const updateChatRoom = async (roomId, data) => {
   const { data: res } = await axiosInstance.put(`/chat/rooms/${roomId}`, data);
   return res;

--- a/src/api/projectRoles.js
+++ b/src/api/projectRoles.js
@@ -1,0 +1,16 @@
+import { axiosInstance } from './axiosInstance';
+
+export const getProjectMembers = async (projectId) => {
+  const res = await axiosInstance.get(`/user/project-roles/${projectId}`);
+  return res.data;
+};
+
+export const assignProjectRole = async ({ projectId, userId, role }) => {
+  const res = await axiosInstance.post(`/user/project-roles/${projectId}`, { userId, role });
+  return res.data;
+};
+
+export const removeProjectMember = async ({ projectId, userId }) => {
+  const res = await axiosInstance.delete(`/user/project-roles/${projectId}/${userId}`);
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- validate project ownership when listing project users for chats
- require all chat room members to belong to the creator's company and project
- drop stale `userTask` references in models and services
- ensure project role APIs and related controllers use the new `Project` model
- skip creator in chat-room membership checks so project owners can create rooms using only project-assigned users
- add room options menu with member viewer, settings, and leave support
- track user online status and refresh layout for clearer chat experience
- fix chat room list rendering and notification bell nesting to resolve DOM warnings
- ensure chat room creation returns immediately after success, avoiding a `catch` parsing crash
- correct chat room cleanup to use the proper socket leave handler and prevent runtime errors when opening the chat tab
- handle room and message fetch errors and guard against undefined online user lists
- remove inline comment in chat room payload destructuring to prevent a catch-block syntax error
- remove duplicate chat room update handlers and redundant catch block in creation route
- show online member counts in room headers and style bubbles based on sender
- optimistically cache outgoing messages so they appear instantly while awaiting the server
- restore chat routes to the provided version so Node no longer throws an unexpected `catch` token error

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 275 problems, 252 errors, 23 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b9312da18083239cf61bf709d05c3b